### PR TITLE
fix deprecation warning for numpy 1.20 np.bool -> bool

### DIFF
--- a/jurity/_version.py
+++ b/jurity/_version.py
@@ -2,4 +2,4 @@
 # Copyright FMR LLC <opensource@fidelity.com>
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/jurity/utils.py
+++ b/jurity/utils.py
@@ -179,7 +179,7 @@ def check_elementwise_input_type(input_: Union[List, np.ndarray, pd.Series], bin
     check_booleans = all([isinstance(i, bool) for i in input_]) is True
     check_numpy_ints32 = all([isinstance(i, np.int32) for i in input_]) is True
     check_numpy_ints64 = all([isinstance(i, np.int64) for i in input_]) is True
-    check_numpy_booleans = all([isinstance(i, np.bool) for i in input_]) is True
+    check_numpy_booleans = all([isinstance(i, bool) for i in input_]) is True
     check_numpy_floats32 = all([isinstance(i, np.float32) for i in input_]) is True
     check_numpy_floats64 = all([isinstance(i, np.float64) for i in input_]) is True
 


### PR DESCRIPTION
Quick fix of deprecation warning from numpy 1.20 (similar to mabwiser fix)

Signed-off-by: Filip Michalsky <Filip.Michalsky@fmr.com>